### PR TITLE
Peer depend @types/form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "@types/form-data": "2.2.1",
     "eslint": "6.1.0"
+  },
+  "peerDependencies": {
+    "@types/form-data": "^2",
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "eslint": "6.1.0"
   },
   "peerDependencies": {
-    "@types/form-data": "^2",
+    "@types/form-data": "^2"
   }
 }


### PR DESCRIPTION
Because @types/form-data is imported in index.d.ts it should also be installed by end-users writing in TypeScript otherwise compiling their projects will fail, assuming `skibLibCheck` compiler option is not set to `true` (which is default). Noticed this on my own project when I enabled lib checking again which resulted in this error:

```sh
$ yarn build && cross-env NODE_ENV=development node ./dist/app.js
$ yarn lint
$ eslint . --ext .js,.jsx,.ts,.tsx --fix
$ tsc
node_modules/sagiri/index.d.ts:2:27 - error TS7016: Could not find a declaration file for module 'form-data'. 'E:/dev/ribbon/node_modules/form-data/lib/form_data.js' implicitly has an 'any' type.  Try `npm install @types/form-data` if it exists or add a new declaration (.d.ts) file containing `declare module 'form-data';`

2 import * as FormData from 'form-data';
                            ~~~~~~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

and it gets fixed on end-user side with `yarn add -D @types/form-data`