### PR TITLE
Fixed similary -> similarity key in Source

### DIFF
--- a/lib/sagiri.ts
+++ b/lib/sagiri.ts
@@ -128,7 +128,7 @@ export class Sagiri {
           url: data.url,
           site: data.name,
           index: data.id.toString(),
-          similary: parseFloat(result.header.similarity),
+          similarity: parseFloat(result.header.similarity),
           thumbnail: result.header.thumbnail,
           authorName: result.data.author_name,
           authorUrl: result.data.author_url,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,7 @@ export type Source = {
   url: string;
   site: string;
   index: string;
-  similary: number;
+  similarity: number;
   thumbnail: string;
   rating: string;
   authorName: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Well that was awkward to realize when I pulled in v2.0 in my own source
code. Apparently I typo'd in the Source type which affected the return
of the data from the lib as well. It was still being mapped to the API
result properly, but people implementing would have to have edited their
code without this, whoops?

Typos be gone (╯°□°）╯︵ ┻━┻

Signed-off-by: Jeroen Claassens <support@favware.tech>

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)