### PR TITLE
Send correct request form-data headers

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,8 +38,6 @@ type File = string | Buffer | Readable;
  * Creates a function to be used for finding potential sources for a given image.
  */
 const sagiri = (token: string, defaultOptions: Options = { results: 5 }) => {
-  const request = bent('https://saucenao.com', 'json', 'POST');
-
   log('Created Sagiri function with default options:', defaultOptions);
 
   return async (
@@ -99,6 +97,14 @@ const sagiri = (token: string, defaultOptions: Options = { results: 5 }) => {
       log('Adding file as stream or buffer');
       form.append('file', file);
     }
+
+    const request = bent(
+      'https://saucenao.com',
+      'json',
+      'POST',
+      200,
+      form.getHeaders()
+    );
 
     log('Sending request to SauceNAO');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sagiri",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A simple, lightweight and actually good JS wrapper for the SauceNAO API.",
   "author": "sr229",
   "license": "MIT",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #124 by moving where the `request` const is created and using the built-in `getHeaders()` function from `form-data` to populate the request headers.

Tested with a simple CLI file that outputs the JSON returned from SauceNAO.

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

(Sorry for the force rebuilds; had the wrong author/committer set up)