### PR TITLE
Remove inactive maintainer references and fix description

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
-github: Ovyerus
 ko_fi: capuccino
-custom: ["https://paypal.me/notvsaucemichael", "https://liberapay.com/Ovyerus/"]

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "sagiri",
   "version": "3.2.2",
-  "description": "A simple, lightweight and actually good JS wrapper for the SauceNAO API. Forked by Agent_RBY_",
+  "description": "A simple, lightweight and actually good JS wrapper for the SauceNAO API.",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "contributors": [
     "sr229",
-    "Michael Mitchell <michael@ovyerus.com> (https://ovyerus.com)",
     "Agent_RBY_"
   ],
   "homepage": "https://github.com/AgentRBY/Sagiri#readme",
@@ -19,10 +18,6 @@
     "url": "https://github.com/AgentRBY/Sagiri/issues"
   },
   "funding": [
-    {
-      "type": "individual",
-      "url": "https://github.com/sponsors/Ovyerus"
-    },
     {
       "type": "individual",
       "url": "https://ko-fi.com/capuccino"


### PR DESCRIPTION
Removing old inactive maintainers seems logical but I can add them back in if they so wish or once they have showed intent of re-maintaining.

Also it seems #292 forgot to remove their description in the fork so I'll have to clean that as well
